### PR TITLE
Migrate site to static hosting

### DIFF
--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,1 +1,0 @@
-covid19.trialstracker.net

--- a/docs/about/index.html
+++ b/docs/about/index.html
@@ -8,19 +8,12 @@
     />
 
     <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/v/bs4-4.1.1/jq-3.3.1/jszip-2.5.0/dt-1.10.21/b-1.6.3/b-colvis-1.6.3/b-html5-1.6.3/cr-1.5.2/fc-3.3.1/r-2.2.5/sc-2.0.2/sp-1.1.1/sl-1.3.1/datatables.min.css"/>
- 
+
     <script type="text/javascript" src="https://cdn.datatables.net/v/bs4-4.1.1/jq-3.3.1/jszip-2.5.0/dt-1.10.21/b-1.6.3/b-colvis-1.6.3/b-html5-1.6.3/cr-1.5.2/fc-3.3.1/r-2.2.5/sc-2.0.2/sp-1.1.1/sl-1.3.1/datatables.min.js"></script>
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
 
-    <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-96324817-10"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-      gtag('config', 'UA-96324817-10');
-    </script>
+    <script async defer data-domain="covid19.trialstracker.net" src="https://plausible.io/js/plausible.js"></script>
 
   </head>
 
@@ -62,28 +55,28 @@
 
         <p> This service is a work in progress. We hope to iterate, expand, and improve the Tracker in the coming days, weeks, and months as time and resources allow.
         </p>
-      
-      <h2>How does this all work?</h2>  
+
+      <h2>How does this all work?</h2>
         <p>Each week we download the ICTRP COVID-19 dataset and run it through some code to clean up and standardise the data. We then add additional information on the interventions involved in each study, assess for cross-registration, add information on any results we know about, make some basic data visualisations, and then post it all online as a free resource for anyone to view or use!</p>
 
-        <p>A few notes about the data: 
+        <p>A few notes about the data:
           <ul>
-            <li>We've limited the dataset to all newly registered studies since the start of 2020, so some older trials that have added a focus on COVID-19 may be excluded.</li> 
-            <li>In addition we've removed any trials that have identified as "Withdrawn" - that is the trial never happened and this is noted in the registry entry.</li> 
+            <li>We've limited the dataset to all newly registered studies since the start of 2020, so some older trials that have added a focus on COVID-19 may be excluded.</li>
+            <li>In addition we've removed any trials that have identified as "Withdrawn" - that is the trial never happened and this is noted in the registry entry.</li>
             <li>If we know about a trial that the ICTRP dataset has missed, we add it manually.</li>
             <li>Cross-registrations are collapsed into a single parent entry with the known cross registrations noted in the last column of the dataset (for instance, all registered versions of the WHO SOLIDARITY trial are collapsed to the ISRCTN entry). We usually default to the ClinicalTrials.gov registration where possible.</li>
-            <li>Most data on the tracker is automatically taken or derived from the ICTRP dataset. We try to catch the most blantant nonsense automatically but we can't manually verify every datafield so mistakes or conflicting information in registration data given to the ICTRP are inherited by our dataset.</li> 
+            <li>Most data on the tracker is automatically taken or derived from the ICTRP dataset. We try to catch the most blantant nonsense automatically but we can't manually verify every datafield so mistakes or conflicting information in registration data given to the ICTRP are inherited by our dataset.</li>
             <li>Normalisation of sponsor names, extracting information about the interventions in each study, accounting for cross-registration, and adding information on completion dates and results is done manually. If you spot mistakes, typos, or have any suggestions to improve this, please get in touch.</li>
           </ul>
         </p>
 
       <h2>Can I use your data for...?</h2>
         <p>Yes! No need to even ask. Our dataset, and everything else about this project, is fully open and available for anyone to grab and use for their own purposes. Attribution is of course appreciated. If you do find our data useful and do something amazing with it, please share it back! We are excited to see what people can do!</p>
-      
-      <h2>Who made this?</h2>
-        <p>The TrialsTracker project is run by <a href="https://ebmdatalab.net">The DataLab</a> at the University of Oxford. The COVID-19 TrialsTracker is maintained by a team of researchers, coders, and clinicians across The DataLab and <a href="https://www.cebm.net/covid-19/">The Centre for Evidence-Based Medicine (CEBM)</a> with additional input from external collaborators.</p> 
 
-        <h5>Contributors to Date</h5>  
+      <h2>Who made this?</h2>
+        <p>The TrialsTracker project is run by <a href="https://ebmdatalab.net">The DataLab</a> at the University of Oxford. The COVID-19 TrialsTracker is maintained by a team of researchers, coders, and clinicians across The DataLab and <a href="https://www.cebm.net/covid-19/">The Centre for Evidence-Based Medicine (CEBM)</a> with additional input from external collaborators.</p>
+
+        <h5>Contributors to Date</h5>
         <ul>
           <li><b>Project Lead</b></li>
             <ul>

--- a/docs/about/index.html
+++ b/docs/about/index.html
@@ -6,6 +6,7 @@
       name="viewport"
       content="width=device-width, initial-scale=1, shrink-to-fit=no"
     />
+    <title>Covid-19 TrialsTracker</title>
 
     <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/v/bs4-4.1.1/jq-3.3.1/jszip-2.5.0/dt-1.10.21/b-1.6.3/b-colvis-1.6.3/b-html5-1.6.3/cr-1.5.2/fc-3.3.1/r-2.2.5/sc-2.0.2/sp-1.1.1/sl-1.3.1/datatables.min.css"/>
 

--- a/docs/data_viz/index.html
+++ b/docs/data_viz/index.html
@@ -6,6 +6,7 @@
       name="viewport"
       content="width=device-width, initial-scale=1, shrink-to-fit=no"
     />
+    <title>Covid-19 TrialsTracker</title>
 
     <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/v/bs4-4.1.1/jq-3.3.1/jszip-2.5.0/dt-1.10.21/b-1.6.3/b-colvis-1.6.3/b-html5-1.6.3/cr-1.5.2/fc-3.3.1/r-2.2.5/sc-2.0.2/sp-1.1.1/sl-1.3.1/datatables.min.css"/>
 

--- a/docs/data_viz/index.html
+++ b/docs/data_viz/index.html
@@ -8,19 +8,12 @@
     />
 
     <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/v/bs4-4.1.1/jq-3.3.1/jszip-2.5.0/dt-1.10.21/b-1.6.3/b-colvis-1.6.3/b-html5-1.6.3/cr-1.5.2/fc-3.3.1/r-2.2.5/sc-2.0.2/sp-1.1.1/sl-1.3.1/datatables.min.css"/>
- 
+
     <script type="text/javascript" src="https://cdn.datatables.net/v/bs4-4.1.1/jq-3.3.1/jszip-2.5.0/dt-1.10.21/b-1.6.3/b-colvis-1.6.3/b-html5-1.6.3/cr-1.5.2/fc-3.3.1/r-2.2.5/sc-2.0.2/sp-1.1.1/sl-1.3.1/datatables.min.js"></script>
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
 
-     <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-96324817-10"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-      gtag('config', 'UA-96324817-10');
-    </script>
+     <script async defer data-domain="covid19.trialstracker.net" src="https://plausible.io/js/plausible.js"></script>
   </head>
 
     <body>
@@ -57,12 +50,12 @@
         </a>
       </noscript>
       <object class='tableauViz'  style='display:none;'>
-        <param name='host_url' value='https%3A%2F%2Fpublic.tableau.com%2F' /> 
+        <param name='host_url' value='https%3A%2F%2Fpublic.tableau.com%2F' />
         <param name='embed_code_version' value='3' /> <param name='site_root' value='' />
         <param name='name' value='new_trials_tracker&#47;Dashboard1' />
         <param name='tabs' value='no' />
         <param name='toolbar' value='yes' />
-        <param name='static_image' value='https:&#47;&#47;public.tableau.com&#47;static&#47;images&#47;ne&#47;new_trials_tracker&#47;Dashboard1&#47;1.png' /> 
+        <param name='static_image' value='https:&#47;&#47;public.tableau.com&#47;static&#47;images&#47;ne&#47;new_trials_tracker&#47;Dashboard1&#47;1.png' />
         <param name='animate_transition' value='yes' />
         <param name='display_static_image' value='yes' />
         <param name='display_spinner' value='yes' />
@@ -70,16 +63,16 @@
         <param name='display_count' value='yes' />
         <param name='filter' value='publish=yes' />
       </object></div>
-      </center>                
+      </center>
 
-      <script type='text/javascript'>                    
-      var divElement = document.getElementById('viz1585253299474');                    
-      var vizElement = divElement.getElementsByTagName('object')[0];                    
+      <script type='text/javascript'>
+      var divElement = document.getElementById('viz1585253299474');
+      var vizElement = divElement.getElementsByTagName('object')[0];
       vizElement.style.minWidth='420px';vizElement.style.maxWidth='850px';
-      vizElement.style.width='100%';vizElement.style.height='887px'; 
-      var scriptElement = document.createElement('script');                    
-      scriptElement.src = 'https://public.tableau.com/javascripts/api/viz_v1.js';                    
-      vizElement.parentNode.insertBefore(scriptElement, vizElement);                
+      vizElement.style.width='100%';vizElement.style.height='887px';
+      var scriptElement = document.createElement('script');
+      scriptElement.src = 'https://public.tableau.com/javascripts/api/viz_v1.js';
+      vizElement.parentNode.insertBefore(scriptElement, vizElement);
       </script>
 
   </body>
@@ -97,4 +90,3 @@
   </font>
   </footer>
 </html>
- 

--- a/docs/figures/index.html
+++ b/docs/figures/index.html
@@ -6,6 +6,7 @@
       name="viewport"
       content="width=device-width, initial-scale=1, shrink-to-fit=no"
     />
+    <title>Covid-19 TrialsTracker</title>
 
     <link
       rel="stylesheet"

--- a/docs/index.html
+++ b/docs/index.html
@@ -8,20 +8,13 @@
     />
 
     <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/v/bs4-4.1.1/jq-3.3.1/jszip-2.5.0/dt-1.10.21/b-1.6.3/b-colvis-1.6.3/b-html5-1.6.3/cr-1.5.2/fc-3.3.1/r-2.2.5/sc-2.0.2/sp-1.1.1/sl-1.3.1/datatables.min.css"/>
- 
+
     <script type="text/javascript" src="https://cdn.datatables.net/v/bs4-4.1.1/jq-3.3.1/jszip-2.5.0/dt-1.10.21/b-1.6.3/b-colvis-1.6.3/b-html5-1.6.3/cr-1.5.2/fc-3.3.1/r-2.2.5/sc-2.0.2/sp-1.1.1/sl-1.3.1/datatables.min.js"></script>
-    
+
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
 
-    <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-96324817-10"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-      gtag('config', 'UA-96324817-10');
-    </script>
+    <script async defer data-domain="covid19.trialstracker.net" src="https://plausible.io/js/plausible.js"></script>
   </head>
 
   <body>
@@ -115,8 +108,8 @@
             dom: 'lfBrtip',
             buttons: [{extend:'searchPanes', text: 'Filter', config: {
                     cascadePanes: true
-                }}, 
-                      {extend: 'colvis', text: 'Columns'}, 
+                }},
+                      {extend: 'colvis', text: 'Columns'},
                       {extend: 'colvisRestore', text:'Restore Columns'}],
             "scrollY": 500,
             "scrollX": true,

--- a/docs/index.html
+++ b/docs/index.html
@@ -6,6 +6,7 @@
       name="viewport"
       content="width=device-width, initial-scale=1, shrink-to-fit=no"
     />
+    <title>Covid-19 TrialsTracker</title>
 
     <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/v/bs4-4.1.1/jq-3.3.1/jszip-2.5.0/dt-1.10.21/b-1.6.3/b-colvis-1.6.3/b-html5-1.6.3/cr-1.5.2/fc-3.3.1/r-2.2.5/sc-2.0.2/sp-1.1.1/sl-1.3.1/datatables.min.css"/>
 

--- a/docs/results/index.html
+++ b/docs/results/index.html
@@ -6,6 +6,7 @@
       name="viewport"
       content="width=device-width, initial-scale=1, shrink-to-fit=no"
     />
+    <title>Covid-19 TrialsTracker</title>
 
     <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/v/bs4-4.1.1/jq-3.3.1/jszip-2.5.0/dt-1.10.21/b-1.6.3/b-colvis-1.6.3/b-html5-1.6.3/cr-1.5.2/fc-3.3.1/r-2.2.5/sc-2.0.2/sp-1.1.1/sl-1.3.1/datatables.min.css"/>
 

--- a/docs/results/index.html
+++ b/docs/results/index.html
@@ -8,19 +8,12 @@
     />
 
     <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/v/bs4-4.1.1/jq-3.3.1/jszip-2.5.0/dt-1.10.21/b-1.6.3/b-colvis-1.6.3/b-html5-1.6.3/cr-1.5.2/fc-3.3.1/r-2.2.5/sc-2.0.2/sp-1.1.1/sl-1.3.1/datatables.min.css"/>
- 
+
     <script type="text/javascript" src="https://cdn.datatables.net/v/bs4-4.1.1/jq-3.3.1/jszip-2.5.0/dt-1.10.21/b-1.6.3/b-colvis-1.6.3/b-html5-1.6.3/cr-1.5.2/fc-3.3.1/r-2.2.5/sc-2.0.2/sp-1.1.1/sl-1.3.1/datatables.min.js"></script>
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
 
-    <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-96324817-10"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-      gtag('config', 'UA-96324817-10');
-    </script>
+    <script async defer data-domain="covid19.trialstracker.net" src="https://plausible.io/js/plausible.js"></script>
   </head>
 
   <body>
@@ -48,7 +41,7 @@
             </li>
           </ul>
       </div>
-      
+
       <font size="2">
       <table id="results-table" class="table table-striped">
         <thead>
@@ -98,8 +91,8 @@
             ajax:
               "https://raw.githubusercontent.com/ebmdatalab/covid_trials_tracker-covid/master/notebooks/website_data/results_latest.json",
             dom: 'lfBrtip',
-            buttons: [{extend:'searchPanes', text: 'Filter'}, 
-                      {extend: 'colvis', text: 'Columns'}, 
+            buttons: [{extend:'searchPanes', text: 'Filter'},
+                      {extend: 'colvis', text: 'Columns'},
                       {extend: 'colvisRestore', text:'Restore Columns'}],
             "scrollY": 500,
             "scrollX": true,


### PR DESCRIPTION
Migrate site to static hosting using Cloudflare Pages.

This PR:

- Removes the CNAME file for GitHub Pages deployment
- Replaces the Google Analytics code with Plausible Analytics
- Updates the `docs/figures/index.html` page to load `plotly.js` once
  - This reduces the page size from 5.2mb to 951kb